### PR TITLE
Fix for issue #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Dependencies to run this out are:
 
 If you are running a Debian/Ubuntu Linux distribution you may install it this way:
 
-	sudo apt-get install nodejs npm libpcsclite libpcsclite-dev
+	sudo apt-get install nodejs npm libpcsclite1 libpcsclite-dev
 
 To compile the native sources you may call `node-gyp`:
 


### PR DESCRIPTION
The Debian (and Ubuntu package) is called libpcsclite1 not libpcsclite
