### PR TITLE
Fix compiler warning: control reaches end of non-void function

### DIFF
--- a/src/pcsc-client.cc
+++ b/src/pcsc-client.cc
@@ -318,7 +318,7 @@ namespace PCSC {
 	/**
 	 * Release the PCSC context
 	 */
-	int release_context ( SCARDCONTEXT &hContext ){
+	void release_context ( SCARDCONTEXT &hContext ){
 		 SCardReleaseContext(hContext);
 	}
 } // <- end of namespace

--- a/src/pcsc-client.h
+++ b/src/pcsc-client.h
@@ -38,7 +38,7 @@ namespace PCSC {
 	int init_context( SCARDCONTEXT &hContext );
 	int update_readers( SCARDCONTEXT &hContext, SCARD_READERSTATE *&readersState, v8::Persistent<v8::Object> &readers );
 	int check_card_status( SCARDCONTEXT &hContext, SCARD_READERSTATE *&readersState, v8::Persistent<v8::Object> &readers, v8::Local<v8::Function> &callback );
-	int release_context ( SCARDCONTEXT &hContext );
+	void release_context ( SCARDCONTEXT &hContext );
 }
 
 #endif


### PR DESCRIPTION
Change function return type from int to void

Fix compilation warning:
../src/pcsc-client.cc:333:2: warning: control reaches end of non-void function
      [-Wreturn-type]
        }
        ^
